### PR TITLE
Adjustment composer version to 1.7.0 in dockerfile

### DIFF
--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -2,4 +2,4 @@ FROM php:7.2-fpm
 
 RUN apt-get update && apt-get install -y git zip curl
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=1.7.0


### PR DESCRIPTION
Hi, there are some adjustments in your dockerfile, because there is an error the current composer version doesn't match with laravel 5.6 , so I changed the dockerfile configuration to use specific composer version 1.7.0 - released 2018-08-03

<hr>

*Before :*
![Screenshot from 2022-06-24 01-48-07](https://user-images.githubusercontent.com/46585811/175380582-6e4fb7d0-c814-4020-8797-ada52f66f057.png)

*After :*
![Screenshot from 2022-06-24 02-30-35](https://user-images.githubusercontent.com/46585811/175382000-fe47f61e-c4ac-4288-905a-178f3f171c11.png)



